### PR TITLE
Import `DependencyGraph` from the `rustsec` crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - cargo clippy --all
   - cargo build --release
   - cargo test --release
-  - cargo doc --no-deps
+  - cargo test --all-features --release

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
 ![Apache 2.0 OR MIT licensed][license-image]
 [![Gitter Chat][gitter-image]][gitter-link]
 
-Self-contained Cargo.lock parser with optional dependency graph analysis
+Self-contained Cargo.lock parser with optional dependency graph analysis,
+used by [RustSec].
+
+When the `dependency-graph` feature of this crate is enabled, it supports
+computing a directed graph of the dependency tree expressed in the lockfile,
+modeled using the [`petgraph`] crate.
 
 [Documentation][docs-link]
 
@@ -35,8 +40,8 @@ additional terms or conditions.
 
 [crate-image]: https://img.shields.io/crates/v/cargo-lock.svg
 [crate-link]: https://crates.io/crates/cargo-lock
-[docs-image]: https://docs.rs/rustsec/badge.svg
-[docs-link]: https://docs.rs/rustsec/
+[docs-image]: https://docs.rs/cargo-lock/badge.svg
+[docs-link]: https://docs.rs/cargo-lock/
 [build-image]: https://travis-ci.org/RustSec/cargo-lock.svg?branch=master
 [build-link]: https://travis-ci.org/RustSec/cargo-lock
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
@@ -48,5 +53,6 @@ additional terms or conditions.
 
 [//]: # (general links)
 
+[`petgraph`]: https://github.com/petgraph/petgraph
 [LICENSE-APACHE]: https://github.com/RustSec/cargo-lock/blob/master/LICENSE-APACHE
 [LICENSE-MIT]: https://github.com/RustSec/cargo-lock/blob/master/LICENSE-MIT

--- a/src/dependency_graph.rs
+++ b/src/dependency_graph.rs
@@ -1,0 +1,139 @@
+//! Dependency graphs computed from `Cargo.lock` files.
+//!
+//! Uses the `petgraph` crate for modeling the dependency structure.
+
+pub use petgraph;
+
+use crate::{
+    error::{Error, ErrorKind},
+    lockfile::Lockfile,
+    package::{self, Package},
+};
+use petgraph::graph::NodeIndex;
+use std::collections::BTreeMap as Map;
+
+/// Dependency graph (modeled using `petgraph`)
+pub type Graph = petgraph::graph::Graph<Package, Edge>;
+
+/// Nodes in the dependency graph
+pub type Nodes = Map<package::Name, NodeIndex>;
+
+/// Dependency graph computed from a `Cargo.lock` file
+#[derive(Clone, Debug)]
+pub struct DependencyGraph {
+    /// Dependency graph for a particular package
+    graph: Graph,
+
+    /// Package data associated with nodes in the graph
+    nodes: Nodes,
+
+    /// Root node of the dependency graph
+    root_node: NodeIndex,
+}
+
+impl DependencyGraph {
+    /// Construct a new dependency graph for the given [`Lockfile`]
+    pub fn new(lockfile: &Lockfile) -> Result<Self, Error> {
+        let mut graph = Graph::new();
+        let mut nodes = Map::new();
+
+        let root_package = find_root_package(lockfile)?;
+        let root_node = graph.add_node(root_package.clone());
+
+        // TODO(tarcieri): index nodes by (name, version) tuples
+        nodes.insert(root_package.name.clone(), root_node);
+
+        let mut dep_graph = Self {
+            graph,
+            nodes,
+            root_node,
+        };
+
+        dep_graph.add_dependencies(lockfile, root_package, root_node);
+        Ok(dep_graph)
+    }
+
+    /// Get the dependency graph
+    pub fn graph(&self) -> &Graph {
+        &self.graph
+    }
+
+    /// Get the nodes of the dependency graph
+    pub fn nodes(&self) -> &Nodes {
+        &self.nodes
+    }
+
+    /// Get the root package in the dependency graph
+    pub fn root_package(&self) -> &Package {
+        &self.graph[self.root_node]
+    }
+
+    /// Add the dependencies of a given package to the given node
+    fn add_dependencies(&mut self, lockfile: &Lockfile, package: &Package, parent: NodeIndex) {
+        for dependency in lockfile.dependencies(package) {
+            let node = self.graph.add_node(dependency.clone());
+            self.nodes.insert(dependency.name.clone(), node);
+            self.graph.add_edge(parent, node, Edge);
+            self.add_dependencies(lockfile, dependency, node);
+        }
+    }
+}
+
+/// Find the root package in the given lockfile
+fn find_root_package(lockfile: &Lockfile) -> Result<&Package, Error> {
+    let mut dependency_counts = Map::new();
+
+    for package in &lockfile.packages {
+        dependency_counts.entry(&package.name).or_insert(0);
+
+        for dependency in &package.dependencies {
+            *dependency_counts.entry(&dependency.name).or_insert(0) += 1;
+        }
+    }
+
+    let root_package_name = *dependency_counts
+        .iter()
+        .find(|(_, count)| **count == 0)
+        .ok_or_else(|| format_err!(ErrorKind::Parse, "couldn't find root package"))?
+        .0;
+
+    Ok(lockfile
+        .packages
+        .iter()
+        .find(|package| &package.name == root_package_name)
+        .unwrap())
+}
+
+/// Graph edges. These are presently just a placeholder.
+// TODO(tarcieri): use these for e.g. VersionReqs?
+#[derive(Clone, Debug)]
+pub struct Edge;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Load the `rustsec` crate's `Cargo.lock`
+    fn load_lockfile() -> Lockfile {
+        Lockfile::load("Cargo.lock").unwrap()
+    }
+
+    #[test]
+    fn root_package() {
+        let lockfile = load_lockfile();
+        assert_eq!(
+            find_root_package(&lockfile).unwrap().name.as_str(),
+            "cargo-lock"
+        );
+    }
+
+    #[test]
+    fn computed_graph() {
+        let lockfile = load_lockfile();
+        let dependencies = DependencyGraph::new(&lockfile).unwrap();
+        let root_package = dependencies.root_package();
+        assert_eq!(root_package.name.as_str(), "cargo-lock");
+
+        // TODO(tarcieri): test dependency graph construction
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
-//! `cargo-lock`: Self-contained Cargo.lock parser with optional dependency
+//! `cargo-lock`: Self-contained `Cargo.lock` parser with optional dependency
 //! graph analysis.
+//!
+//! When the `dependency-graph` feature of this crate is enabled, it supports
+//! computing a directed graph of the dependency tree expressed in the lockfile,
+//! modeled using the [`petgraph`] crate.
+//!
+//! [`petgraph`]: https://github.com/petgraph/petgraph
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
@@ -11,6 +17,13 @@
 #[macro_use]
 pub mod error;
 
+#[cfg(feature = "dependency-graph")]
+pub mod dependency_graph;
 pub mod lockfile;
 pub mod metadata;
 pub mod package;
+
+pub use self::{error::Error, lockfile::Lockfile, package::Package};
+
+#[cfg(feature = "dependency-graph")]
+pub use self::dependency_graph::DependencyGraph;


### PR DESCRIPTION
Models the dependency tree expressed in a `Cargo.lock` file using the `petgraph` crate.