### PR TITLE
Index DependencyGraph by package::Release

### DIFF
--- a/src/dependency_graph.rs
+++ b/src/dependency_graph.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap as Map;
 pub type Graph = petgraph::graph::Graph<Package, Edge>;
 
 /// Nodes in the dependency graph
-pub type Nodes = Map<package::Name, NodeIndex>;
+pub type Nodes = Map<package::Release, NodeIndex>;
 
 /// Dependency graph computed from a `Cargo.lock` file
 #[derive(Clone, Debug)]
@@ -41,7 +41,7 @@ impl DependencyGraph {
         let root_node = graph.add_node(root_package.clone());
 
         // TODO(tarcieri): index nodes by (name, version) tuples
-        nodes.insert(root_package.name.clone(), root_node);
+        nodes.insert(root_package.release(), root_node);
 
         let mut dep_graph = Self {
             graph,
@@ -72,7 +72,7 @@ impl DependencyGraph {
     fn add_dependencies(&mut self, lockfile: &Lockfile, package: &Package, parent: NodeIndex) {
         for dependency in lockfile.dependencies(package) {
             let node = self.graph.add_node(dependency.clone());
-            self.nodes.insert(dependency.name.clone(), node);
+            self.nodes.insert(dependency.release(), node);
             self.graph.add_edge(parent, node, Edge);
             self.add_dependencies(lockfile, dependency, node);
         }

--- a/src/package.rs
+++ b/src/package.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// Information about a Rust package (as sourced from `Cargo.lock`)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Package {
-    /// Name of a crate
+    /// Name of the package
     pub name: Name,
 
     /// Crate version (using `semver`)
@@ -23,6 +23,26 @@ pub struct Package {
         deserialize_with = "deserialize_dependencies"
     )]
     pub dependencies: Vec<Package>,
+}
+
+impl Package {
+    /// Get release info for a particular package
+    pub fn release(&self) -> Release {
+        Release {
+            name: self.name.clone(),
+            version: self.version.clone(),
+        }
+    }
+}
+
+/// Package releases: name/version tuples used to index the graph
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct Release {
+    /// Name of the package
+    pub name: Name,
+
+    /// Crate version (using `semver`)
+    pub version: Version,
 }
 
 /// Serialize a package in `[[package.dependencies]]`


### PR DESCRIPTION
Adds a type for modeling the 2-tuple of a package name and its version, since a lockfile may potentially contain multiple versions of the same package when semver allows for it.