### PR TITLE
dependency_graph: Move petgraph types into a module

### DIFF
--- a/src/dependency_graph.rs
+++ b/src/dependency_graph.rs
@@ -12,11 +12,23 @@ use crate::{
 use petgraph::graph::NodeIndex;
 use std::collections::BTreeMap as Map;
 
-/// Dependency graph (modeled using `petgraph`)
-pub type Graph = petgraph::graph::Graph<Package, Edge>;
+/// `petgraph`-based graph types
+pub mod graph {
+    use super::{package, Map, NodeIndex, Package};
 
-/// Nodes in the dependency graph
-pub type Nodes = Map<package::Release, NodeIndex>;
+    /// Dependency graph (modeled using `petgraph`)
+    pub type Graph = petgraph::graph::Graph<Package, Edge>;
+
+    /// Nodes in the dependency graph
+    pub type Nodes = Map<package::Release, NodeIndex>;
+
+    /// Graph edges. These are presently just a placeholder.
+    // TODO(tarcieri): use these for e.g. VersionReqs?
+    #[derive(Clone, Debug)]
+    pub struct Edge;
+}
+
+use self::graph::*;
 
 /// Dependency graph computed from a `Cargo.lock` file
 #[derive(Clone, Debug)]
@@ -103,11 +115,6 @@ fn find_root_package(lockfile: &Lockfile) -> Result<&Package, Error> {
         .find(|package| &package.name == root_package_name)
         .unwrap())
 }
-
-/// Graph edges. These are presently just a placeholder.
-// TODO(tarcieri): use these for e.g. VersionReqs?
-#[derive(Clone, Debug)]
-pub struct Edge;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,11 @@ pub mod lockfile;
 pub mod metadata;
 pub mod package;
 
-pub use self::{error::Error, lockfile::Lockfile, package::Package};
+pub use self::{
+    error::{Error, ErrorKind},
+    lockfile::Lockfile,
+    package::Package,
+};
 
 #[cfg(feature = "dependency-graph")]
 pub use self::dependency_graph::DependencyGraph;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -9,8 +9,7 @@ use std::{
 };
 
 /// Package metadata
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Metadata(Map<Checksum, Hash>);
+pub type Metadata = Map<Checksum, Hash>;
 
 /// Package checksum info
 // TODO(tarcieri): properly parse checksum strings


### PR DESCRIPTION
Moves them under `cargo_lock::dependency_graph::graph`