### PR TITLE
Allow empty `[metadata]` in Cargo.lock files

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -18,6 +18,7 @@ pub struct Lockfile {
     pub packages: Vec<Package>,
 
     /// Package metadata
+    #[serde(default)]
     pub metadata: Metadata,
 }
 


### PR DESCRIPTION
A package with no dependencies has no `[metadata]` section.