### PR TITLE
v0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.2.1] (2019-09-21)
+
+- Allow empty `[metadata]` in Cargo.lock files ([#9])
+
 ## [0.2.0] (2019-09-21)
 
 - dependency_graph: Move `petgraph` types into a module ([#7])
@@ -6,6 +10,8 @@
 
 - Initial release
 
+[0.2.1]: https://github.com/RustSec/cargo-lock/pull/10
+[#9]: https://github.com/RustSec/cargo-lock/pull/9
 [0.2.0]: https://github.com/RustSec/cargo-lock/pull/8
 [#7]: https://github.com/RustSec/cargo-lock/pull/7
 [0.1.0]: https://github.com/RustSec/cargo-lock/pull/5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-lock"
 description = """
 Self-contained Cargo.lock parser with optional dependency graph analysis
 """
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/0.2.0"
+    html_root_url = "https://docs.rs/cargo-lock/0.2.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Allow empty `[metadata]` in Cargo.lock files (#9)