### PR TITLE
metadata: Generalize into `Key` and `Value` types

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,28 +5,33 @@ use serde::{de, ser, Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 /// Package metadata
-pub type Metadata = Map<Checksum, Hash>;
+pub type Metadata = Map<Key, Value>;
 
-/// Package checksum info
-// TODO(tarcieri): properly parse checksum strings
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Checksum(String);
+/// Keys for the `[metadata]` table
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Key(String);
 
-impl fmt::Display for Checksum {
+impl AsRef<str> for Key {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for Checksum {
+impl FromStr for Key {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        Ok(Checksum(s.to_owned()))
+        Ok(Key(s.to_owned()))
     }
 }
 
-impl<'de> Deserialize<'de> for Checksum {
+impl<'de> Deserialize<'de> for Key {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
         String::deserialize(deserializer)?
@@ -35,32 +40,37 @@ impl<'de> Deserialize<'de> for Checksum {
     }
 }
 
-impl Serialize for Checksum {
+impl Serialize for Key {
     fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)
     }
 }
 
-/// Package hashes
-// TODO(tarcieri): properly parse package hashes
+/// Values in the `[metadata]` table
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Hash(String);
+pub struct Value(String);
 
-impl fmt::Display for Hash {
+impl AsRef<str> for Value {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for Hash {
+impl FromStr for Value {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        Ok(Hash(s.to_owned()))
+        Ok(Value(s.to_owned()))
     }
 }
 
-impl<'de> Deserialize<'de> for Hash {
+impl<'de> Deserialize<'de> for Value {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
         String::deserialize(deserializer)?
@@ -69,7 +79,7 @@ impl<'de> Deserialize<'de> for Hash {
     }
 }
 
-impl Serialize for Hash {
+impl Serialize for Value {
     fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)
     }


### PR DESCRIPTION
Treats `[metadata]` as a "stringly typed" key/value map, and avoids any concrete treatment of the values.