### PR TITLE
Use two-pass dependency tree computation

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -32,9 +32,7 @@ pub struct Dependency {
 impl Dependency {
     /// Does the given [`Package`] exactly match this `Dependency`?
     pub fn matches(&self, package: &Package) -> bool {
-        self.name == package.name
-            && self.version == package.version
-            && self.source == package.source
+        self.name == package.name && self.version == package.version
     }
 }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -38,22 +38,6 @@ impl Lockfile {
         }
     }
 
-    /// Enumerate dependent [`Package`] types for the given parent [`Package`].
-    pub fn dependent_packages(&self, package: &Package) -> Vec<&Package> {
-        let mut result = vec![];
-
-        for dependency in &package.dependencies {
-            result.push(
-                self.packages
-                    .iter()
-                    .find(|pkg| dependency.matches(pkg))
-                    .unwrap(),
-            )
-        }
-
-        result
-    }
-
     /// Get the dependency tree for this `Lockfile`. Returns an error if the
     /// contents of this lockfile aren't well structured.
     ///


### PR DESCRIPTION
Switches from a recursive dependency graph computation to a flat two-pass approach instead:

1. Add all packages to the graph as nodes
2. Add edges to the package nodes

This is much simpler approach as opposed to the previous buggy implementation.