### PR TITLE
v2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [2.0.0] (2019-09-25)
+
+- Use two-pass dependency tree computation ([#20])
+- Remove `Lockfile::root_package()` ([#18])
+
 ## [1.0.0] (2019-09-24)
 
 - dependency/tree: Render trees to an `io::Write` ([#16])
@@ -16,6 +21,9 @@
 
 - Initial release
 
+[2.0.0]: https://github.com/RustSec/cargo-lock/pull/21
+[#20]: https://github.com/RustSec/cargo-lock/pull/20
+[#18]: https://github.com/RustSec/cargo-lock/pull/18
 [1.0.0]: https://github.com/RustSec/cargo-lock/pull/17
 [#16]: https://github.com/RustSec/cargo-lock/pull/16
 [#14]: https://github.com/RustSec/cargo-lock/pull/14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "2.0.0-pre"
+version = "2.0.0"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/2.0.0-pre"
+    html_root_url = "https://docs.rs/cargo-lock/2.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Use two-pass dependency tree computation (#20)
- Remove `Lockfile::root_package()` (#18)