### PR TITLE
Add `package::Checksum`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,44 +29,6 @@ macro_rules! fail {
     };
 }
 
-/// Error type
-#[derive(Debug)]
-pub struct Error {
-    /// Kind of error
-    kind: ErrorKind,
-
-    /// Message providing additional information
-    msg: String,
-}
-
-impl Error {
-    /// Create a new error with the given message
-    pub fn new<S: ToString>(kind: ErrorKind, msg: &S) -> Self {
-        Self {
-            kind,
-            msg: msg.to_string(),
-        }
-    }
-
-    /// Obtain the inner `ErrorKind` for this error
-    pub fn kind(&self) -> ErrorKind {
-        self.kind
-    }
-
-    /// Obtain the associated error message
-    pub fn msg(&self) -> &str {
-        &self.msg
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", &self.kind, &self.msg)
-    }
-}
-
-impl std::error::Error for Error {}
-
 /// Custom error type for this library
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
@@ -110,8 +72,52 @@ impl From<semver::ReqParseError> for Error {
     }
 }
 
+impl From<std::num::ParseIntError> for Error {
+    fn from(other: std::num::ParseIntError) -> Self {
+        format_err!(ErrorKind::Parse, &other)
+    }
+}
+
 impl From<toml::de::Error> for Error {
     fn from(other: toml::de::Error) -> Self {
         format_err!(ErrorKind::Parse, &other)
     }
 }
+
+/// Error type
+#[derive(Debug)]
+pub struct Error {
+    /// Kind of error
+    kind: ErrorKind,
+
+    /// Message providing additional information
+    msg: String,
+}
+
+impl Error {
+    /// Create a new error with the given message
+    pub fn new<S: ToString>(kind: ErrorKind, msg: &S) -> Self {
+        Self {
+            kind,
+            msg: msg.to_string(),
+        }
+    }
+
+    /// Obtain the inner `ErrorKind` for this error
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Obtain the associated error message
+    pub fn msg(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", &self.kind, &self.msg)
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,10 +1,14 @@
 //! Rust packages enumerated in `Cargo.lock`
 
+pub mod checksum;
+pub mod name;
+pub mod source;
+
+pub use self::{checksum::Checksum, name::Name, source::Source};
 pub use semver::Version;
 
-use crate::{dependency::Dependency, error::Error};
+use crate::dependency::Dependency;
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
 
 /// Information about a Rust package (as sourced from `Cargo.lock`)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
@@ -17,6 +21,9 @@ pub struct Package {
 
     /// Source for the package
     pub source: Option<Source>,
+
+    /// Checksum for this package
+    pub checksum: Option<Checksum>,
 
     /// Dependencies of the package
     #[serde(default)]
@@ -31,69 +38,5 @@ impl From<Package> for Dependency {
             version: Some(pkg.version.clone()),
             source: pkg.source,
         }
-    }
-}
-
-/// Name of a Rust `[[package]]`
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct Name(String);
-
-impl Name {
-    /// Get package name as an `&str`
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl FromStr for Name {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Error> {
-        // TODO(tarcieri): ensure name is valid
-        Ok(Name(s.into()))
-    }
-}
-
-/// Source for a Rust `[[package]]`
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct Source(String);
-
-impl Source {
-    /// Get source as an `&str`
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<str> for Source {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for Source {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl FromStr for Source {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Error> {
-        // TODO(tarcieri): ensure source is valid
-        Ok(Source(s.into()))
     }
 }

--- a/src/package/checksum.rs
+++ b/src/package/checksum.rs
@@ -1,0 +1,124 @@
+//! Package checksums (i.e. SHA-256 digests)
+
+use crate::{Error, ErrorKind};
+use serde::{de, ser, Deserialize, Serialize};
+pub use std::{fmt, str::FromStr};
+
+/// Cryptographic checksum (SHA-256) for a package
+#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum Checksum {
+    /// SHA-256 digest of a package
+    Sha256([u8; 32]),
+}
+
+impl Checksum {
+    /// Is this checksum SHA-256?
+    pub fn is_sha256(&self) -> bool {
+        self.as_sha256().is_some()
+    }
+
+    /// If this is a SHA-256 checksum, get the raw bytes
+    pub fn as_sha256(&self) -> Option<[u8; 32]> {
+        match self {
+            Checksum::Sha256(digest) => Some(*digest),
+        }
+    }
+}
+
+impl FromStr for Checksum {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        if s.len() != 64 {
+            fail!(
+                ErrorKind::Parse,
+                "invalid checksum: expected 64 hex chars, got {}",
+                s.len()
+            );
+        }
+
+        let mut digest = [0u8; 32];
+
+        for (i, byte) in digest.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(&s[(i * 2)..=(i * 2) + 1], 16)?;
+        }
+
+        Ok(Checksum::Sha256(digest))
+    }
+}
+
+impl fmt::Debug for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Checksum::Sha256(_) => write!(f, "Sha256({:x})", self),
+        }
+    }
+}
+
+impl fmt::Display for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", self)
+    }
+}
+
+impl fmt::LowerHex for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Checksum::Sha256(digest) => {
+                for b in digest {
+                    write!(f, "{:02x}", b)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Checksum::Sha256(digest) => {
+                for b in digest {
+                    write!(f, "{:02X}", b)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for Checksum {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let hex = String::deserialize(deserializer)?;
+        hex.parse().map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for Checksum {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Checksum, ErrorKind};
+
+    #[test]
+    fn checksum_round_trip() {
+        let checksum_str = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5";
+        let checksum = checksum_str.parse::<Checksum>().unwrap();
+        assert_eq!(checksum_str, checksum.to_string());
+    }
+
+    #[test]
+    fn invalid_checksum() {
+        // Missing one hex letter
+        let invalid_str = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f";
+        let error = invalid_str.parse::<Checksum>().err().unwrap();
+        assert_eq!(error.kind(), ErrorKind::Parse);
+    }
+}

--- a/src/package/name.rs
+++ b/src/package/name.rs
@@ -1,0 +1,37 @@
+//! Package names
+
+use crate::Error;
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// Name of a Rust `[[package]]`
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct Name(String);
+
+impl Name {
+    /// Get package name as an `&str`
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for Name {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        // TODO(tarcieri): ensure name is valid
+        Ok(Name(s.into()))
+    }
+}

--- a/src/package/source.rs
+++ b/src/package/source.rs
@@ -1,0 +1,37 @@
+//! Rust package sources
+
+use crate::Error;
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// Source for a Rust `[[package]]`
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct Source(String);
+
+impl Source {
+    /// Get source as an `&str`
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for Source {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for Source {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        // TODO(tarcieri): ensure source is valid
+        Ok(Source(s.into()))
+    }
+}

--- a/tests/lockfile.rs
+++ b/tests/lockfile.rs
@@ -8,6 +8,7 @@ use cargo_lock::{metadata, Lockfile, Version};
 #[test]
 fn load_our_own_lockfile() {
     let lockfile = Lockfile::load("Cargo.lock").unwrap();
+    dbg!(&lockfile);
     assert!(lockfile.packages.len() > 0);
 }
 


### PR DESCRIPTION
The `ResolveVersion::V2` format moves package checksums from the `[[metadata]]` section into a `checksum` field on each `[[package]]`.

This commit adds support for parsing them.