### PR TITLE
Detect V1 vs V2 Cargo.lock files (fixes #26)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ pub mod package;
 pub use self::{
     dependency::Dependency,
     error::{Error, ErrorKind},
-    lockfile::Lockfile,
+    lockfile::{Lockfile, ResolveVersion},
+    metadata::Metadata,
     package::{Package, Version},
 };
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,5 +1,10 @@
 //! Parser for `Cargo.lock` files
 
+mod parser;
+pub mod version;
+
+pub use self::version::ResolveVersion;
+
 #[cfg(feature = "dependency-tree")]
 use crate::dependency::Tree;
 use crate::{
@@ -7,20 +12,19 @@ use crate::{
     metadata::Metadata,
     package::Package,
 };
-use serde::{Deserialize, Serialize};
 use std::{fs, path::Path, str::FromStr, string::ToString};
 use toml;
 
 /// Parsed Cargo.lock file containing dependencies
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Lockfile {
+    /// Version of the Lockfile
+    pub version: ResolveVersion,
+
     /// Dependencies enumerated in the lockfile
-    #[serde(rename = "package")]
     pub packages: Vec<Package>,
 
     /// Package metadata
-    #[serde(default)]
     pub metadata: Metadata,
 }
 
@@ -56,8 +60,9 @@ impl FromStr for Lockfile {
     }
 }
 
-impl ToString for Lockfile {
-    fn to_string(&self) -> String {
-        toml::to_string(self).unwrap()
-    }
-}
+// TODO(tarcieri): add ResolveVersion-respecting `Serialize` impl
+// impl ToString for Lockfile {
+//    fn to_string(&self) -> String {
+//        toml::to_string(self).unwrap()
+//    }
+//}

--- a/src/lockfile/parser.rs
+++ b/src/lockfile/parser.rs
@@ -1,0 +1,119 @@
+//! serde-based lockfile parser
+//!
+//! This uses a custom visitor impl (extracted from the proc macro one)
+//! which allows us to do postprocessing to detect the V1 vs V2 formats
+//! and ensure the end-user is supplied a consistent representation.
+
+use super::{version::ResolveVersion, Lockfile};
+use crate::{metadata::Metadata, package::Package};
+use serde::{de, Deserialize};
+use std::{fmt, marker::PhantomData};
+
+impl<'de> Deserialize<'de> for Lockfile {
+    fn deserialize<D>(deserialize: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        /// Field names in `Cargo.lock`
+        const FIELDS: &[&str] = &["package", "metadata"];
+
+        /// Fields in `Cargo.lock`
+        enum Field {
+            Package,
+            Metadata,
+        }
+
+        /// Serde visitor for fields in `Cargo.lock`
+        struct FieldVisitor;
+
+        impl<'de> de::Visitor<'de> for FieldVisitor {
+            type Value = Field;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("field identifier")
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                match value {
+                    "package" => Ok(Field::Package),
+                    "metadata" => Ok(Field::Metadata),
+                    _ => Err(de::Error::unknown_field(value, FIELDS)),
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            #[inline]
+            fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                de::Deserializer::deserialize_identifier(deserializer, FieldVisitor)
+            }
+        }
+
+        /// Lockfile visitor
+        struct Visitor<'de> {
+            marker: PhantomData<Lockfile>,
+            lifetime: PhantomData<&'de ()>,
+        }
+
+        impl<'de> de::Visitor<'de> for Visitor<'de> {
+            type Value = Lockfile;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("struct Lockfile")
+            }
+
+            #[inline]
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut packages: Option<Vec<Package>> = None;
+                let mut metadata: Option<Metadata> = None;
+
+                while let Some(key) = de::MapAccess::next_key::<Field>(&mut map)? {
+                    match key {
+                        Field::Package => {
+                            if packages.is_some() {
+                                return Err(<A::Error as de::Error>::duplicate_field("package"));
+                            }
+
+                            packages = Some(de::MapAccess::next_value::<Vec<Package>>(&mut map)?);
+                        }
+                        Field::Metadata => {
+                            if metadata.is_some() {
+                                return Err(<A::Error as de::Error>::duplicate_field("metadata"));
+                            }
+
+                            metadata = Some(de::MapAccess::next_value::<Metadata>(&mut map)?);
+                        }
+                    }
+                }
+
+                let packages =
+                    packages.ok_or_else(|| <A::Error as de::Error>::missing_field("package"))?;
+
+                let metadata = metadata.unwrap_or_default();
+
+                // Autodetect Cargo.lock resolve version based on its contents
+                let version =
+                    ResolveVersion::detect(&packages, &metadata).map_err(de::Error::custom)?;
+
+                Ok(Lockfile {
+                    version,
+                    packages,
+                    metadata,
+                })
+            }
+        }
+
+        de::Deserializer::deserialize_struct(
+            deserialize,
+            "Lockfile",
+            FIELDS,
+            Visitor {
+                marker: PhantomData,
+                lifetime: PhantomData,
+            },
+        )
+    }
+}

--- a/src/lockfile/version.rs
+++ b/src/lockfile/version.rs
@@ -1,0 +1,54 @@
+//! Lockfile versions
+
+use crate::{
+    error::{Error, ErrorKind},
+    metadata::Metadata,
+    package::Package,
+};
+
+/// Lockfile versions
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum ResolveVersion {
+    /// The original `Cargo.lock` format which places checksums in the
+    /// `[[metadata]]` table.
+    V1,
+
+    /// The new `Cargo.lock` format which is optimized to prevent merge
+    /// conflicts. For more information, see:
+    ///
+    /// <https://github.com/rust-lang/cargo/pull/7070>
+    V2,
+}
+
+impl ResolveVersion {
+    /// Autodetect the version of a lockfile from the packages
+    pub fn detect(packages: &[Package], metadata: &Metadata) -> Result<Self, Error> {
+        // V1: look for [[metadata]] keys beginning with checksum
+        let is_v1 = metadata
+            .keys()
+            .any(|key| key.as_ref().starts_with("checksum "));
+
+        // V2: look for `checksum` fields in `[package]`
+        let is_v2 = packages.iter().any(|package| package.checksum.is_some());
+
+        if is_v1 && is_v2 {
+            fail!(ErrorKind::Parse, "malformed lockfile: contains checksums in both [[package]] and [[metadata]] sections");
+        }
+
+        if is_v1 {
+            Ok(ResolveVersion::V1)
+        } else {
+            // Default to V2
+            Ok(ResolveVersion::V2)
+        }
+    }
+}
+
+/// V2 format is now the default.
+///
+///See: <https://github.com/rust-lang/cargo/pull/7579>
+impl Default for ResolveVersion {
+    fn default() -> Self {
+        ResolveVersion::V2
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -34,9 +34,8 @@ impl FromStr for Key {
 impl<'de> Deserialize<'de> for Key {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
-        String::deserialize(deserializer)?
-            .parse()
-            .map_err(D::Error::custom)
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(D::Error::custom)
     }
 }
 
@@ -73,9 +72,8 @@ impl FromStr for Value {
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
-        String::deserialize(deserializer)?
-            .parse()
-            .map_err(D::Error::custom)
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(D::Error::custom)
     }
 }
 

--- a/tests/lockfile.rs
+++ b/tests/lockfile.rs
@@ -2,21 +2,23 @@
 
 // TODO(tarcieri): add more example `Cargo.lock` files which cover more scenarios
 
-use cargo_lock::{metadata, Lockfile, Version};
+use cargo_lock::{metadata, Lockfile, ResolveVersion, Version};
 
 /// Load this crate's own `Cargo.lock` file
 #[test]
 fn load_our_own_lockfile() {
     let lockfile = Lockfile::load("Cargo.lock").unwrap();
     dbg!(&lockfile);
-    assert!(lockfile.packages.len() > 0);
+    assert_eq!(lockfile.version, ResolveVersion::V2);
+    assert_ne!(lockfile.packages.len(), 0);
 }
 
-/// Load a non-trivial example `Cargo.lock` file (from the Cargo project itself)
+/// Load example V1 `Cargo.lock` file (from the Cargo project itself)
 #[test]
-fn load_example_cargo_lockfile() {
+fn load_example_v1_lockfile() {
     let lockfile = Lockfile::load("tests/support/Cargo.lock.example-cargo").unwrap();
 
+    assert_eq!(lockfile.version, ResolveVersion::V1);
     assert_eq!(lockfile.packages.len(), 141);
     assert_eq!(lockfile.metadata.len(), 136);
 
@@ -36,10 +38,11 @@ fn load_example_cargo_lockfile() {
     );
 }
 
-/// Load a non-trivial example `Cargo.lock` file (from rustc)
+/// Load example V2 `Cargo.lock` file (from rustc)
 #[test]
-fn load_example_rustc_lockfile() {
+fn load_example_v2_lockfile() {
     let lockfile = Lockfile::load("tests/support/Cargo.lock.example-rustc").unwrap();
+    assert_eq!(lockfile.version, ResolveVersion::V2);
     assert_eq!(lockfile.packages.len(), 472);
     assert_eq!(lockfile.metadata.len(), 0);
 }
@@ -57,7 +60,7 @@ mod tree {
             .dependency_tree()
             .unwrap();
 
-        assert!(tree.nodes().len() > 0);
+        assert_ne!(tree.nodes().len(), 0);
     }
 
     /// Compute a dependency graph from a non-trivial example `Cargo.lock`


### PR DESCRIPTION
Ideally we would normalize the representation between the two versions, however for now this merely detects which one is in use.

This temporarily removes `Serialize` support for `Lockfile`, with the idea of adding custom serializers which can encode both the V1 and V2 format from a common, normalized representation.