### PR TITLE
Add support Cargo.lock `patch` and `root` (fixes #30)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod dependency;
 pub mod lockfile;
 pub mod metadata;
 pub mod package;
+pub mod patch;
 
 pub use self::{
     dependency::Dependency,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -8,9 +8,11 @@ pub use self::version::ResolveVersion;
 #[cfg(feature = "dependency-tree")]
 use crate::dependency::Tree;
 use crate::{
+    dependency::Dependency,
     error::{Error, ErrorKind},
     metadata::Metadata,
     package::Package,
+    patch::Patch,
 };
 use std::{fs, path::Path, str::FromStr, string::ToString};
 use toml;
@@ -24,8 +26,14 @@ pub struct Lockfile {
     /// Dependencies enumerated in the lockfile
     pub packages: Vec<Package>,
 
+    /// Legacy "root" dependency for backwards compatibility
+    pub root: Option<Dependency>,
+
     /// Package metadata
     pub metadata: Metadata,
+
+    /// Patches
+    pub patch: Patch,
 }
 
 impl Lockfile {

--- a/src/lockfile/version.rs
+++ b/src/lockfile/version.rs
@@ -5,9 +5,10 @@ use crate::{
     metadata::Metadata,
     package::Package,
 };
+use serde::{Deserialize, Serialize};
 
 /// Lockfile versions
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub enum ResolveVersion {
     /// The original `Cargo.lock` format which places checksums in the
     /// `[[metadata]]` table.

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,0 +1,18 @@
+//! The `[[patch]]` section
+
+use crate::dependency::Dependency;
+use serde::{Deserialize, Serialize};
+
+/// The `[[patch]]` section of `Cargo.lock`
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Patch {
+    /// Unused patches
+    pub unused: Vec<Dependency>,
+}
+
+impl Patch {
+    /// Is the `[patch]` section empty?
+    pub fn is_empty(&self) -> bool {
+        self.unused.is_empty()
+    }
+}


### PR DESCRIPTION
This commit should bring parity between Cargo's `EncodableResolve` type (i.e. serialization type for Cargo.lock) and our `Lockfile` type.

It adds support for the legacy `root` dependency, along with the `[[patch.unused]]` section.