### PR TITLE
(Re-)Add Serialize impl for Lockfile (fixes #32)

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,6 +1,6 @@
 //! Parser for `Cargo.lock` files
 
-mod parser;
+mod encoding;
 pub mod version;
 
 pub use self::version::ResolveVersion;
@@ -68,9 +68,8 @@ impl FromStr for Lockfile {
     }
 }
 
-// TODO(tarcieri): add ResolveVersion-respecting `Serialize` impl
-// impl ToString for Lockfile {
-//    fn to_string(&self) -> String {
-//        toml::to_string(self).unwrap()
-//    }
-//}
+impl ToString for Lockfile {
+    fn to_string(&self) -> String {
+        toml::to_string(self).unwrap()
+    }
+}

--- a/src/package.rs
+++ b/src/package.rs
@@ -26,7 +26,7 @@ pub struct Package {
     pub checksum: Option<Checksum>,
 
     /// Dependencies of the package
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<Dependency>,
 }
 

--- a/tests/lockfile.rs
+++ b/tests/lockfile.rs
@@ -8,9 +8,18 @@ use cargo_lock::{metadata, Lockfile, ResolveVersion, Version};
 #[test]
 fn load_our_own_lockfile() {
     let lockfile = Lockfile::load("Cargo.lock").unwrap();
-    dbg!(&lockfile);
     assert_eq!(lockfile.version, ResolveVersion::V2);
     assert_ne!(lockfile.packages.len(), 0);
+}
+
+/// Ensure we can reserialize this crate's own `Cargo.lock` file
+#[test]
+fn serialize_our_own_lockfile() {
+    let lockfile = Lockfile::load("Cargo.lock").unwrap();
+    let reserialized = lockfile.to_string();
+
+    let lockfile2 = reserialized.parse::<Lockfile>().unwrap();
+    assert_eq!(lockfile, lockfile2);
 }
 
 /// Load example V1 `Cargo.lock` file (from the Cargo project itself)


### PR DESCRIPTION
Extracted from the `serde_derive`-generated `Serialize` impl.

We use this rather than the upstream one to allow for format detection.