### PR TITLE
Overhaul encoding: use serde_derive, proper V1/V2 support

### DIFF
--- a/src/dependency/tree.rs
+++ b/src/dependency/tree.rs
@@ -31,12 +31,12 @@ impl Tree {
         // Populate all graph nodes in the first pass
         for package in &lockfile.packages {
             let node_index = graph.add_node(package.clone());
-            nodes.insert(Dependency::from(package.clone()), node_index);
+            nodes.insert(Dependency::from(package), node_index);
         }
 
         // Populate all graph edges in the second pass
         for package in &lockfile.packages {
-            let parent_index = nodes[&Dependency::from(package.clone())];
+            let parent_index = nodes[&Dependency::from(package)];
 
             for dependency in &package.dependencies {
                 if let Some(node_index) = nodes.get(dependency) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ pub use self::{
     error::{Error, ErrorKind},
     lockfile::{Lockfile, ResolveVersion},
     metadata::Metadata,
-    package::{Package, Version},
+    package::{Checksum, Name, Package, Source, Version},
+    patch::Patch,
 };
 
 /// Use `BTreeMap` for all `Map` types in the crate

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -5,10 +5,8 @@ pub mod version;
 
 pub use self::version::ResolveVersion;
 
-#[cfg(feature = "dependency-tree")]
-use crate::dependency::Tree;
+use self::encoding::EncodableLockfile;
 use crate::{
-    dependency::Dependency,
     error::{Error, ErrorKind},
     metadata::Metadata,
     package::Package,
@@ -16,6 +14,9 @@ use crate::{
 };
 use std::{fs, path::Path, str::FromStr, string::ToString};
 use toml;
+
+#[cfg(feature = "dependency-tree")]
+use crate::dependency::Tree;
 
 /// Parsed Cargo.lock file containing dependencies
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -27,7 +28,7 @@ pub struct Lockfile {
     pub packages: Vec<Package>,
 
     /// Legacy "root" dependency for backwards compatibility
-    pub root: Option<Dependency>,
+    pub root: Option<Package>,
 
     /// Package metadata
     pub metadata: Metadata,
@@ -70,6 +71,6 @@ impl FromStr for Lockfile {
 
 impl ToString for Lockfile {
     fn to_string(&self) -> String {
-        toml::to_string(self).unwrap()
+        toml::to_string(&EncodableLockfile::from(self)).unwrap()
     }
 }

--- a/src/lockfile/encoding.rs
+++ b/src/lockfile/encoding.rs
@@ -4,197 +4,392 @@
 //! the V1 vs V2 formats and ensure the end-user is supplied a consistent
 //! representation regardless of which version is in use.
 
-use super::{version::ResolveVersion, Lockfile};
-use crate::{dependency::Dependency, metadata::Metadata, package::Package, patch::Patch};
+use super::{Lockfile, ResolveVersion};
+use crate::{
+    metadata, Checksum, Dependency, Error, ErrorKind, Metadata, Name, Package, Patch, Source,
+    Version,
+};
 use serde::{de, ser, Deserialize, Serialize};
-use std::{fmt, marker::PhantomData};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    str::FromStr,
+};
 
-// TODO(tarcieri): handle V1 vs V2 format when serializing
-impl Serialize for Lockfile {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut field_count = 1; // package section (mandatory)
+impl<'de> Deserialize<'de> for Lockfile {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw_lockfile = EncodableLockfile::deserialize(deserializer)?;
 
-        if self.root.is_some() {
-            field_count += 1;
-        }
-
-        if !self.metadata.is_empty() {
-            field_count += 1;
-        }
-
-        if !self.patch.is_empty() {
-            field_count += 1;
-        }
-
-        let mut state = ser::Serializer::serialize_struct(serializer, "Lockfile", field_count)?;
-
-        ser::SerializeStruct::serialize_field(&mut state, "package", &self.packages)?;
-
-        if self.root.is_some() {
-            ser::SerializeStruct::serialize_field(&mut state, "root", &self.root)?;
-        } else {
-            ser::SerializeStruct::skip_field(&mut state, "root")?;
-        }
-
-        if self.metadata.is_empty() {
-            ser::SerializeStruct::skip_field(&mut state, "metadata")?;
-        } else {
-            ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
-        }
-
-        if self.patch.is_empty() {
-            ser::SerializeStruct::skip_field(&mut state, "patch")?;
-        } else {
-            ser::SerializeStruct::serialize_field(&mut state, "patch", &self.patch)?;
-        }
-
-        ser::SerializeStruct::end(state)
+        raw_lockfile.try_into().map_err(de::Error::custom)
     }
 }
 
-impl<'de> Deserialize<'de> for Lockfile {
-    fn deserialize<D>(deserialize: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        /// Field names in `Cargo.lock`
-        const FIELDS: &[&str] = &["package", "root", "metadata", "patch"];
+impl Serialize for Lockfile {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        EncodableLockfile::from(self).serialize(serializer)
+    }
+}
 
-        /// Fields in `Cargo.lock`
-        enum Field {
-            /// `[[package]]` section
-            Package,
+/// Serialization-oriented equivalent to [`Lockfile`]
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct EncodableLockfile {
+    /// Packages in the lockfile
+    #[serde(default)]
+    pub(super) package: Vec<EncodablePackage>,
 
-            /// Legacy `[root]` section
-            Root,
+    /// Legacy root package (preserved for compatibility)
+    pub(super) root: Option<EncodablePackage>,
 
-            /// `[metadata]` section
-            Metadata,
+    /// Metadata fields
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub(super) metadata: Metadata,
 
-            /// `[patch]` section
-            Patch,
+    /// Patch section
+    #[serde(default, skip_serializing_if = "Patch::is_empty")]
+    pub(super) patch: Patch,
+}
 
-            /// Ignore unknown field
-            Ignore,
-        }
+impl EncodableLockfile {
+    /// Attempt to find a checksum for a package in a V1 lockfile
+    pub fn find_checksum(&self, package: &Package) -> Option<Checksum> {
+        for (key, value) in &self.metadata {
+            let mut key_parts = key.as_ref().split(' ');
 
-        /// Serde visitor for fields in `Cargo.lock`
-        struct FieldVisitor;
-
-        impl<'de> de::Visitor<'de> for FieldVisitor {
-            type Value = Field;
-
-            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str("field identifier")
+            if key_parts.next() != Some("checksum") {
+                continue;
             }
 
-            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
-                match value {
-                    "package" => Ok(Field::Package),
-                    "root" => Ok(Field::Root),
-                    "metadata" => Ok(Field::Metadata),
-                    "patch" => Ok(Field::Patch),
-                    _ => Ok(Field::Ignore),
+            match key_parts.next() {
+                Some(n) if n == package.name.as_ref() => (),
+                _ => continue,
+            }
+
+            match key_parts.next() {
+                Some(v) if v == package.version.to_string() => (),
+                _ => continue,
+            }
+
+            return value.as_ref().parse().ok();
+        }
+
+        None
+    }
+}
+
+impl TryFrom<EncodableLockfile> for Lockfile {
+    type Error = Error;
+
+    fn try_from(raw_lockfile: EncodableLockfile) -> Result<Lockfile, Error> {
+        let version = ResolveVersion::detect(&raw_lockfile.package, &raw_lockfile.metadata)?;
+        let mut packages = Vec::with_capacity(raw_lockfile.package.len());
+
+        for raw_package in &raw_lockfile.package {
+            packages.push(match version {
+                // In the V1 format, all dependencies are fully qualified with
+                // their versions, but their checksums are stored in metadata.
+                ResolveVersion::V1 => {
+                    let mut pkg = Package::try_from(raw_package)?;
+                    pkg.checksum = raw_lockfile.find_checksum(&pkg);
+                    pkg
                 }
-            }
+
+                // In the V2 format, we may need to look up dependency versions
+                // from the other packages listed in the lockfile
+                ResolveVersion::V2 => raw_package.resolve(&raw_lockfile.package)?,
+            });
         }
 
-        impl<'de> Deserialize<'de> for Field {
-            #[inline]
-            fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
+        Ok(Lockfile {
+            version,
+            packages,
+            root: raw_lockfile
+                .root
+                .as_ref()
+                .map(|root| root.try_into())
+                .transpose()?,
+            metadata: raw_lockfile.metadata,
+            patch: raw_lockfile.patch,
+        })
+    }
+}
 
-        /// Lockfile visitor
-        struct Visitor<'de> {
-            marker: PhantomData<Lockfile>,
-            lifetime: PhantomData<&'de ()>,
-        }
+impl From<&Lockfile> for EncodableLockfile {
+    fn from(lockfile: &Lockfile) -> EncodableLockfile {
+        let mut packages = Vec::with_capacity(lockfile.packages.len());
+        let mut metadata = lockfile.metadata.clone();
 
-        impl<'de> de::Visitor<'de> for Visitor<'de> {
-            type Value = Lockfile;
+        for package in &lockfile.packages {
+            let mut raw_pkg = EncodablePackage::from(package);
+            let checksum_key = format!("checksum {}", Dependency::from(package))
+                .parse::<metadata::Key>()
+                .unwrap();
 
-            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str("struct Lockfile")
-            }
-
-            #[inline]
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: de::MapAccess<'de>,
-            {
-                let mut packages: Option<Vec<Package>> = None;
-                let mut root: Option<Dependency> = None;
-                let mut metadata: Option<Metadata> = None;
-                let mut patch: Option<Patch> = None;
-
-                while let Some(key) = de::MapAccess::next_key::<Field>(&mut map)? {
-                    match key {
-                        Field::Package => {
-                            if packages.is_some() {
-                                return Err(<A::Error as de::Error>::duplicate_field("package"));
-                            }
-
-                            packages = Some(de::MapAccess::next_value::<Vec<Package>>(&mut map)?);
-                        }
-                        Field::Root => {
-                            if root.is_some() {
-                                return Err(<A::Error as de::Error>::duplicate_field("root"));
-                            }
-
-                            root = Some(de::MapAccess::next_value::<Dependency>(&mut map)?);
-                        }
-                        Field::Metadata => {
-                            if metadata.is_some() {
-                                return Err(<A::Error as de::Error>::duplicate_field("metadata"));
-                            }
-
-                            metadata = Some(de::MapAccess::next_value::<Metadata>(&mut map)?);
-                        }
-                        Field::Patch => {
-                            if patch.is_some() {
-                                return Err(<A::Error as de::Error>::duplicate_field("patch"));
-                            }
-
-                            patch = Some(de::MapAccess::next_value::<Patch>(&mut map)?);
-                        }
-                        Field::Ignore => (),
+            match lockfile.version {
+                // In the V1 format, we need to remove the checksum from
+                // packages and add it to metadata
+                ResolveVersion::V1 => {
+                    if let Some(checksum) = raw_pkg.checksum.take() {
+                        let value = checksum.to_string().parse::<metadata::Value>().unwrap();
+                        metadata.insert(checksum_key, value);
                     }
                 }
 
-                let packages =
-                    packages.ok_or_else(|| <A::Error as de::Error>::missing_field("package"))?;
+                // In the V2 format, we need to remove the version/source from
+                // unambiguous dependencies, and remove checksums from the
+                // metadata table if present
+                ResolveVersion::V2 => {
+                    raw_pkg.v2_deps(&lockfile.packages);
+                    metadata.remove(&checksum_key);
+                }
+            }
 
-                let metadata = metadata.unwrap_or_default();
+            packages.push(raw_pkg);
+        }
 
-                let patch = patch.unwrap_or_default();
+        EncodableLockfile {
+            package: packages,
+            root: lockfile.root.as_ref().map(|root| root.into()),
+            metadata,
+            patch: lockfile.patch.clone(),
+        }
+    }
+}
 
-                // Autodetect Cargo.lock resolve version based on its contents
-                let version =
-                    ResolveVersion::detect(&packages, &metadata).map_err(de::Error::custom)?;
+/// Serialization-oriented equivalent to [`Package`]
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct EncodablePackage {
+    /// Package name
+    pub(super) name: Name,
 
-                Ok(Lockfile {
-                    version,
-                    root,
-                    packages,
-                    metadata,
-                    patch,
-                })
+    /// Package version
+    pub(super) version: Version,
+
+    /// Source of a package
+    pub(super) source: Option<Source>,
+
+    /// Package checksum
+    pub(super) checksum: Option<Checksum>,
+
+    /// Package dependencies
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) dependencies: Vec<EncodableDependency>,
+
+    /// Replace directive
+    pub(super) replace: Option<EncodableDependency>,
+}
+
+impl EncodablePackage {
+    /// Resolve all of the dependencies of a package, which in the V2 format
+    /// may be abbreviated to prevent merge conflicts
+    fn resolve(&self, packages: &[EncodablePackage]) -> Result<Package, Error> {
+        let mut dependencies = Vec::with_capacity(self.dependencies.len());
+
+        for dep in &self.dependencies {
+            dependencies.push(dep.resolve(packages)?);
+        }
+
+        Ok(Package {
+            name: self.name.clone(),
+            version: self.version.clone(),
+            source: self.source.clone(),
+            checksum: self.checksum.clone(),
+            dependencies,
+            replace: self
+                .replace
+                .as_ref()
+                .map(|rep| rep.try_into())
+                .transpose()?,
+        })
+    }
+
+    /// Prepare `ResolveVersion::V2` dependencies by removing ones which are unambiguous
+    fn v2_deps(&mut self, packages: &[Package]) {
+        for dependency in &mut self.dependencies {
+            dependency.v2(packages);
+        }
+    }
+}
+
+/// Note: this only works for `ResolveVersion::V1` dependencies.
+impl TryFrom<&EncodablePackage> for Package {
+    type Error = Error;
+
+    fn try_from(raw_package: &EncodablePackage) -> Result<Package, Error> {
+        raw_package.resolve(&[])
+    }
+}
+
+impl From<&Package> for EncodablePackage {
+    fn from(package: &Package) -> EncodablePackage {
+        EncodablePackage {
+            name: package.name.clone(),
+            version: package.version.clone(),
+            source: package.source.clone(),
+            checksum: package.checksum.clone(),
+            dependencies: package
+                .dependencies
+                .iter()
+                .map(|dep| dep.into())
+                .collect::<Vec<_>>(),
+            replace: package.replace.as_ref().map(|rep| rep.into()),
+        }
+    }
+}
+
+/// Package dependencies
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(super) struct EncodableDependency {
+    /// Name of the dependency
+    pub(super) name: Name,
+
+    /// Version of the dependency
+    pub(super) version: Option<Version>,
+
+    /// Source for the dependency
+    pub(super) source: Option<Source>,
+}
+
+impl EncodableDependency {
+    /// Resolve this dependency, which in the V2 format may be abbreviated to
+    /// prevent merge conflicts
+    pub fn resolve(&self, packages: &[EncodablePackage]) -> Result<Dependency, Error> {
+        let mut version = None;
+        let mut source = None;
+
+        if let Some(v) = &self.version {
+            version = Some(v.clone());
+            source = self.source.clone();
+        } else {
+            for pkg in packages {
+                if pkg.name == self.name {
+                    if version.is_some() {
+                        fail!(ErrorKind::Parse, "ambiguous dependency: {}", self.name);
+                    }
+
+                    version = Some(pkg.version.clone());
+                    source = pkg.source.clone();
+                }
+            }
+        };
+
+        if version.is_none() {
+            fail!(
+                ErrorKind::Parse,
+                "couldn't resolve dependency: {}",
+                self.name
+            );
+        }
+
+        Ok(Dependency {
+            name: self.name.clone(),
+            version: version.unwrap(),
+            source,
+        })
+    }
+
+    /// Prepare `ResolveVersion::V2` dependencies by removing ones which are unambiguous
+    pub fn v2(&mut self, packages: &[Package]) {
+        let mut matching = vec![];
+
+        for package in packages {
+            if package.name == self.name {
+                matching.push(package);
             }
         }
 
-        de::Deserializer::deserialize_struct(
-            deserialize,
-            "Lockfile",
-            FIELDS,
-            Visitor {
-                marker: PhantomData,
-                lifetime: PhantomData,
-            },
-        )
+        // TODO(tarcieri): better handle other cases?
+        if matching.len() == 1 {
+            self.version = None;
+            self.source = None;
+        }
+    }
+}
+
+impl FromStr for EncodableDependency {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        let mut parts = s.split_whitespace();
+
+        let name = parts
+            .next()
+            .ok_or_else(|| format_err!(ErrorKind::Parse, "empty dependency string"))?
+            .parse()?;
+
+        let version = parts.next().map(FromStr::from_str).transpose()?;
+
+        let source = parts
+            .next()
+            .map(|s| {
+                if s.len() < 2 || !s.starts_with('(') || !s.ends_with(')') {
+                    Err(format_err!(
+                        ErrorKind::Parse,
+                        "malformed source in dependency: {}",
+                        s
+                    ))
+                } else {
+                    s[1..(s.len() - 1)].parse()
+                }
+            })
+            .transpose()?;
+
+        if parts.next().is_some() {
+            fail!(ErrorKind::Parse, "malformed dependency: {}", s);
+        }
+
+        Ok(Self {
+            name,
+            version,
+            source,
+        })
+    }
+}
+
+impl fmt::Display for EncodableDependency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.name)?;
+
+        if let Some(version) = &self.version {
+            write!(f, " {}", version)?;
+        }
+
+        if let Some(source) = &self.source {
+            write!(f, " ({})", source)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Note: this only works for `ResolveVersion::V1` dependencies.
+impl TryFrom<&EncodableDependency> for Dependency {
+    type Error = Error;
+
+    fn try_from(raw_dependency: &EncodableDependency) -> Result<Dependency, Error> {
+        raw_dependency.resolve(&[])
+    }
+}
+
+impl From<&Dependency> for EncodableDependency {
+    fn from(package: &Dependency) -> EncodableDependency {
+        EncodableDependency {
+            name: package.name.clone(),
+            version: Some(package.version.clone()),
+            source: package.source.clone(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for EncodableDependency {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for EncodableDependency {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
     }
 }

--- a/src/lockfile/version.rs
+++ b/src/lockfile/version.rs
@@ -1,9 +1,9 @@
 //! Lockfile versions
 
+use super::encoding::EncodablePackage;
 use crate::{
     error::{Error, ErrorKind},
     metadata::Metadata,
-    package::Package,
 };
 use serde::{Deserialize, Serialize};
 
@@ -23,11 +23,12 @@ pub enum ResolveVersion {
 
 impl ResolveVersion {
     /// Autodetect the version of a lockfile from the packages
-    pub fn detect(packages: &[Package], metadata: &Metadata) -> Result<Self, Error> {
+    pub(super) fn detect(
+        packages: &[EncodablePackage],
+        metadata: &Metadata,
+    ) -> Result<Self, Error> {
         // V1: look for [[metadata]] keys beginning with checksum
-        let is_v1 = metadata
-            .keys()
-            .any(|key| key.as_ref().starts_with("checksum "));
+        let is_v1 = metadata.keys().any(|key| key.is_checksum());
 
         // V2: look for `checksum` fields in `[package]`
         let is_v2 = packages.iter().any(|package| package.checksum.is_some());

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,6 +11,13 @@ pub type Metadata = Map<Key, Value>;
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Key(String);
 
+impl Key {
+    /// Is this metadata key a checksum entry?
+    pub fn is_checksum(&self) -> bool {
+        self.0.starts_with("checksum ")
+    }
+}
+
 impl AsRef<str> for Key {
     fn as_ref(&self) -> &str {
         &self.0

--- a/src/package.rs
+++ b/src/package.rs
@@ -28,15 +28,7 @@ pub struct Package {
     /// Dependencies of the package
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<Dependency>,
-}
 
-impl From<Package> for Dependency {
-    /// Get the [`Dependency`] requirement for this `[[package]]`
-    fn from(pkg: Package) -> Dependency {
-        Self {
-            name: pkg.name.clone(),
-            version: Some(pkg.version.clone()),
-            source: pkg.source,
-        }
-    }
+    /// Replace directive
+    pub replace: Option<Dependency>,
 }


### PR DESCRIPTION
This replaces the bespoke serde `Serializer`/`Deserializer` implementations with `serde_derive`-generated ones, following the approach used by [Cargo's `core/resolver/encode.rs`](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/resolver/encode.rs), which is to create separate `Encodable*` types for the various parts of the lockfile.

Copying this approach, we can derive serializers/deserializers for these types.

Additionally, this PR does all of the work to provide a consistent decoded representation between the V1 and V2 formats, resolving V2 dependencies.

It also adds serializer support for producing both V1 and V2 lockfiles. This should permit transcoding lockfiles from V1 -> V2 and V2 -> V1.