### PR TITLE
Initial CLI with `translate` subcommand

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,42 @@ on:
 name: Rust
 
 jobs:
+  build:
+    name: Build (--no-default-features)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Run cargo build --no-default-features --lib
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+        with:
+          use-cross: false
+          command: build
+          args: --no-default-features --lib
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 name = "cargo-lock"
 version = "3.0.0"
 dependencies = [
+ "gumdrop",
  "petgraph",
  "semver",
  "serde",
@@ -22,6 +23,26 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "gumdrop"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "idna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["cargo", "dependency", "lock", "lockfile"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+gumdrop = { version = "0.7", optional = true }
 petgraph = { version = "0.5", optional = true }
 semver = { version = "0.9", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
@@ -22,7 +23,6 @@ toml = "0.5"
 url = "2"
 
 [features]
+default = ["cli", "dependency-tree"]
+cli = ["gumdrop"]
 dependency-tree = ["petgraph"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ the [`cargo-tree`] crate.
 
 `cargo-lock` requires Rust **1.35** or later.
 
+## Command Line Interface
+
+This crate provides a `cargo lock` subcommand which can be installed with:
+
+```
+$ cargo install cargo-lock
+```
+
+It supports the following subcommands:
+
+- `translate`: translate `Cargo.lock` files between the V1 and V2 formats
+
+See the [crate documentation][docs-link] for more detailed usage information.
+
 ## License
 
 Licensed under either of:

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,0 +1,90 @@
+//! The `cargo lock` subcommand
+
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_qualifications)]
+
+use cargo_lock::{Lockfile, ResolveVersion};
+use gumdrop::Options;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+/// Wrapper toplevel command for the `cargo lock` subcommand
+#[derive(Options)]
+enum CargoLock {
+    #[options(help = "the `cargo lock` Cargo subcommand")]
+    Lock(Command),
+}
+
+#[derive(Debug, Options)]
+enum Command {
+    #[options(help = "translate a Cargo.toml file")]
+    Translate(TranslateCmd),
+}
+
+#[derive(Debug, Options)]
+struct TranslateCmd {
+    /// Input `Cargo.lock` file
+    #[options(short = "f", help = "input Cargo.lock file to translate")]
+    file: Option<PathBuf>,
+
+    /// Output `Cargo.lock` file
+    #[options(short = "o", help = "output Cargo.lock file (default STDOUT)")]
+    output: Option<PathBuf>,
+
+    /// Cargo.lock format version to translate to
+    #[options(short = "v", help = "Cargo.lock resolve version to output")]
+    version: Option<ResolveVersion>,
+}
+
+impl TranslateCmd {
+    /// Translate `Cargo.lock` to a different format version
+    pub fn run(&self) {
+        let input = self
+            .file
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or_else(|| Path::new("Cargo.lock"));
+
+        let output = self
+            .output
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or_else(|| Path::new("-"));
+
+        let mut lockfile = Lockfile::load(input).unwrap_or_else(|e| {
+            eprintln!("*** error: {}", e);
+            exit(1);
+        });
+
+        lockfile.version = self.version.unwrap_or_default();
+        let lockfile_toml = lockfile.to_string();
+
+        if output == Path::new("-") {
+            println!("{}", &lockfile_toml);
+        } else {
+            fs::write(output, lockfile_toml.as_bytes()).unwrap_or_else(|e| {
+                eprintln!("*** error: {}", e);
+                exit(1);
+            });
+        }
+    }
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+
+    match CargoLock::parse_args_default(&args[1..]) {
+        Ok(CargoLock::Lock(cmd)) => match cmd {
+            Command::Translate(translate) => translate.run(),
+        },
+        Err(e) => {
+            eprintln!("*** error: {}", e);
+            eprintln!("USAGE:");
+            eprintln!("{}", Command::usage());
+            exit(1);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,40 @@
 //! for both the V1 and V2 (merge-friendly) formats, as well as optional
 //! dependency tree analysis features. Used by [RustSec].
 //!
-//! # Usage
+//! # Usage Example
 //!
 //! ```
 //! use cargo_lock::Lockfile;
 //!
 //! let lockfile = Lockfile::load("Cargo.lock").unwrap();
 //! println!("number of dependencies: {}", lockfile.packages.len());
+//! ```
+//!
+//! # Command Line Interface
+//!
+//! This crate provides a `cargo lock` Cargo subcommand which can be installed
+//! by running the following:
+//!
+//! ```text
+//! $ cargo install cargo-lock
+//! ```
+//!
+//! It supports the following subcommands:
+//!
+//! ## `translate`: translate `Cargo.lock` files between the V1 and V2 formats
+//!
+//! The `cargo lock translate` subcommand can translate V1 Cargo.lock files to
+//! the [new V2 format] and vice versa:
+//!
+//! ```text
+//! $ cargo lock translate
+//! ```
+//!
+//! ...will translate Cargo.lock to the V2 format. To translate a V2 Cargo.lock
+//! file back to the V1 format, use:
+//!
+//! ```text
+//! $ cargo lock translate --v1
 //! ```
 //!
 //! # Dependency tree
@@ -19,6 +46,7 @@
 //! printing dependency trees ala the [`cargo-tree`] crate.
 //!
 //! [RustSec]: https://rustsec.org/
+//! [new V2 format]: https://github.com/rust-lang/cargo/pull/7070
 //! [`petgraph`]: https://github.com/petgraph/petgraph
 //! [`cargo-tree`]: https://github.com/sfackler/cargo-tree
 

--- a/src/lockfile/version.rs
+++ b/src/lockfile/version.rs
@@ -6,6 +6,7 @@ use crate::{
     metadata::Metadata,
 };
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// Lockfile versions
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
@@ -52,5 +53,21 @@ impl ResolveVersion {
 impl Default for ResolveVersion {
     fn default() -> Self {
         ResolveVersion::V2
+    }
+}
+
+impl FromStr for ResolveVersion {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "1" => Ok(ResolveVersion::V1),
+            "2" => Ok(ResolveVersion::V2),
+            _ => fail!(
+                ErrorKind::Parse,
+                "invalid Cargo.lock format version: `{}`",
+                s
+            ),
+        }
     }
 }


### PR DESCRIPTION
Adds an initial command line interface available via `cargo install` which supports translating from the V1 to V2 formats (and back).