### PR TITLE
v4.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## [4.0.0] (2020-01-22)
+
+- Command line interface ([#40], [#42], [#43])
+- Add helper methods for working with checksum metadata ([#38])
+- Use minified version of Cargo's `SourceId` type ([#36])
+- Overhaul encoding: use serde_derive, proper V1/V2 support ([#35])
+- Add support Cargo.lock `patch` and `root` ([#33])
+- Detect V1 vs V2 Cargo.lock files ([#31])
+- Update `petgraph` requirement from 0.4 to 0.5 ([#28])
+- Add `package::Checksum` ([#29])
+
 ## [3.0.0] (2019-10-01)
 
 - Support `[package.dependencies]` without versions ([#23])
@@ -25,17 +36,34 @@
 
 - Initial release
 
+[4.0.0]: https://github.com/RustSec/cargo-lock/pull/44
+[#43]: https://github.com/RustSec/cargo-lock/pull/43
+[#42]: https://github.com/RustSec/cargo-lock/pull/42
+[#40]: https://github.com/RustSec/cargo-lock/pull/40
+[#38]: https://github.com/RustSec/cargo-lock/pull/38
+[#36]: https://github.com/RustSec/cargo-lock/pull/36
+[#35]: https://github.com/RustSec/cargo-lock/pull/35
+[#33]: https://github.com/RustSec/cargo-lock/pull/33
+[#31]: https://github.com/RustSec/cargo-lock/pull/31
+[#29]: https://github.com/RustSec/cargo-lock/pull/29
+[#28]: https://github.com/RustSec/cargo-lock/pull/28
+
 [3.0.0]: https://github.com/RustSec/cargo-lock/pull/24
 [#23]: https://github.com/RustSec/cargo-lock/pull/23
+
 [2.0.0]: https://github.com/RustSec/cargo-lock/pull/21
 [#20]: https://github.com/RustSec/cargo-lock/pull/20
 [#18]: https://github.com/RustSec/cargo-lock/pull/18
+
 [1.0.0]: https://github.com/RustSec/cargo-lock/pull/17
 [#16]: https://github.com/RustSec/cargo-lock/pull/16
 [#14]: https://github.com/RustSec/cargo-lock/pull/14
 [#11]: https://github.com/RustSec/cargo-lock/pull/11
+
 [0.2.1]: https://github.com/RustSec/cargo-lock/pull/10
 [#9]: https://github.com/RustSec/cargo-lock/pull/9
+
 [0.2.0]: https://github.com/RustSec/cargo-lock/pull/8
 [#7]: https://github.com/RustSec/cargo-lock/pull/7
+
 [0.1.0]: https://github.com/RustSec/cargo-lock/pull/5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "cargo-lock"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! It supports the following subcommands:
 //!
-//! ## `list`: summarize packages in `Cargo.lock`
+//! ### `list`: summarize packages in `Cargo.lock`
 //!
 //! The `cargo lock list` subcommand provides a short synopsis of the
 //! packages enumerated in `Cargo.lock`:
@@ -40,7 +40,7 @@
 //! [...]
 //! ```
 //!
-//! ## `translate`: convert `Cargo.lock` files between the V1 and V2 formats
+//! ### `translate`: convert `Cargo.lock` files between the V1 and V2 formats
 //!
 //! The `cargo lock translate` subcommand can translate V1 Cargo.lock files to
 //! the [new V2 format] and vice versa:
@@ -56,7 +56,7 @@
 //! $ cargo lock translate --v1
 //! ```
 //!
-//! ## `tree`: provide information for how a dependency is included
+//! ### `tree`: provide information for how a dependency is included
 //!
 //! The `cargo lock tree` subcommand (similar to the `cargo-tree` command)
 //! can provide a visualization of how a particular dependency is being used
@@ -95,7 +95,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/3.0.0"
+    html_root_url = "https://docs.rs/cargo-lock/4.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Command line interface (#40, #42, #43)
- Add helper methods for working with checksum metadata (#38)
- Use minified version of Cargo's `SourceId` type (#36)
- Overhaul encoding: use serde_derive, proper V1/V2 support (#35)
- Add support Cargo.lock `patch` and `root` (#33)
- Detect V1 vs V2 Cargo.lock files (#31)
- Update `petgraph` requirement from 0.4 to 0.5 (#28)
- Add `package::Checksum` (#29)