### PR TITLE
lib.rs: fix incorrect flag in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! file back to the V1 format, use:
 //!
 //! ```text
-//! $ cargo lock translate --v1
+//! $ cargo lock translate -v1
 //! ```
 //!
 //! ### `tree`: provide information for how a dependency is included


### PR DESCRIPTION
There is a minor typo in documentation; instead of `--v1` it should be `-v1`
```
$ cargo lock translate --v1
Thu 05 Mar 2020 10:55:09 AM CET

*** error: unrecognized option `--v1`
USAGE:
  list       list packages in Cargo.toml
  translate  translate a Cargo.toml file
  tree       print a dependency tree for the given dependency
```

while `cargo lock translate -v1` works as expected.

Thanks for the extremely useful utility! :+1: 