### PR TITLE
Fix clippy errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,6 @@ use std::{
     fmt::{self, Display},
     io,
 };
-use toml;
 
 /// Create error with a formatted message
 macro_rules! format_err {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -13,7 +13,6 @@ use crate::{
     patch::Patch,
 };
 use std::{fs, path::Path, str::FromStr, string::ToString};
-use toml;
 
 #[cfg(feature = "dependency-tree")]
 use crate::dependency::Tree;


### PR DESCRIPTION
Redundant imports of `toml`